### PR TITLE
Update module4.rst

### DIFF
--- a/source/class1/module4/module4.rst
+++ b/source/class1/module4/module4.rst
@@ -15,7 +15,7 @@ To do so, I prepared a ``kubectl`` Kubernetes Deployment in YAML.
     #. SSH (or WebSSH and ``cd /home/ubuntu/``) to CICD Server
     #. Run this command ``kubectl apply -f /home/ubuntu/k8s_ingress/full_ingress_arcadia.yaml``
     #. You should now see a new namespace ``nginx-ingress`` and a new ingress in the Kubernetes Dashboard on the Jumphost
-    #. Check the Ingress ``arcadia-ingress`` by clicking on the 3 dots on the right and ``edit``
+    #. Check the Ingress ``arcadia-ingress`` (in the ``default`` namespace) by clicking on the 3 dots on the right and ``edit``
     #. Scroll down and check the specs
 
 


### PR DESCRIPTION
There is reference to ``nginx-ingress`` namespace in one step but in the next one, the instruction for switching namespace to ``default`` is missing... at least in my deployment the ``arcadia-ingress`` is in ``default`` namespace.